### PR TITLE
wrong object name in Miller Betweenness preference computation

### DIFF
--- a/pathpy/Paths.py
+++ b/pathpy/Paths.py
@@ -840,7 +840,7 @@ class Paths:
                 p_s = marginal_s[s]
 
                 # add to conditional entropy
-                H_ds += p_s * paths.__Entropy(p_ds, K_s, N_s, method='Miller')
+                H_ds += p_s * Paths.__Entropy(p_ds, K_s, N_s, method='Miller')
 
             #print('H(D|S) = ', H_ds)
 


### PR DESCRIPTION
The `paths` object in the 'Miller' variant of the `BetweennessPreference` is lower case but should be upper case n`Paths`.