### PR TITLE
Ipython auto complete error

### DIFF
--- a/pathpy/MarkovSequence.py
+++ b/pathpy/MarkovSequence.py
@@ -18,16 +18,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     Contact the developer:
-    
+
     E-mail: ischoltes@ethz.ch
     Web:    http://www.ingoscholtes.net
 """
 
-import numpy as _np 
+import numpy as _np
 import collections as _co
 import bisect as _bs
 import itertools as _iter
-import warnings as _w
 
 import scipy.sparse as _sparse
 import scipy.misc as _misc
@@ -40,20 +39,20 @@ from pathpy.Log import Log
 from pathpy.Log import Severity
 
 _np.seterr(all='warn')
-_w.filterwarnings('error')
+
 
 class MarkovSequence:
-    """ Instances of this class can be used to fit 
-        standard higher-order Markov models for 
+    """ Instances of this class can be used to fit
+        standard higher-order Markov models for
         sequences generated from concatenated paths """
 
     def __init__(self, sequence):
-        """ 
-        Generates a Markov model for a sequence, given 
+        """
+        Generates a Markov model for a sequence, given
         as a single list of strings
         """
 
-        ## The sequence to be modeled 
+        ## The sequence to be modeled
         self.sequence = sequence
 
         ## The transition probabilities of higher-order Markov chains
@@ -65,13 +64,13 @@ class MarkovSequence:
 
 
     def fitMarkovModel(self, k=1):
-        """ Generates a k-th order Markov model 
+        """ Generates a k-th order Markov model
             for the underlying sequence
         """
 
         # TODO: Add support for k=0
 
-        assert len(self.sequence)>0, "Error: Empty sequence"        
+        assert len(self.sequence)>0, "Error: Empty sequence"
 
         # MLE fit of transition probabilities
         self.P[k] = _co.defaultdict( lambda:  _co.defaultdict( lambda: 0.0 )  )
@@ -81,7 +80,7 @@ class MarkovSequence:
         # Generate initial memory prefix
         mem = (())
         for s in self.sequence[:k]:
-            mem += (s,)     
+            mem += (s,)
 
         # count state transitions
         for s in self.sequence[k:]:
@@ -99,14 +98,14 @@ class MarkovSequence:
 
 
     def getLikelihood(self, k=1, log=True):
-        """ 
-        Returns the likelihood of the sequence 
-        assuming a k-th order Markov model 
         """
-        
+        Returns the likelihood of the sequence
+        assuming a k-th order Markov model
+        """
+
         if k not in self.P:
             self.fitMarkovModel(k)
-        
+
         L = 0
 
          # Generate initial prefix
@@ -141,10 +140,10 @@ class MarkovSequence:
 
         s = len(self.states[1])
         n = len(self.sequence)-k
-        
-        # the transition matrix of a first-order model with s states has s**2 entries, subject to the 
-        # constraint that entries in each row must sum up to one (thus effectively reducing 
-        # the degrees of freedom by a factor of s, i.e. we have s**2-s**1. Generalizing this to order k, 
+
+        # the transition matrix of a first-order model with s states has s**2 entries, subject to the
+        # constraint that entries in each row must sum up to one (thus effectively reducing
+        # the degrees of freedom by a factor of s, i.e. we have s**2-s**1. Generalizing this to order k,
         # we arrive at s**k * (s-1) = s**(k+1) - s**k derees of freedom
         bic = _np.log(n) * (s**k - s**m) * (s-1) - 2.0 * (L_k-L_m)
 
@@ -166,7 +165,7 @@ class MarkovSequence:
 
         s = len(self.states[1])
         n = len(self.sequence)
-        
+
         aic = 2 * (s**k - s**m) * (s-1) - 2.0 * (L_k - L_m)
 
         return aic
@@ -181,7 +180,7 @@ class MarkovSequence:
         values = []
         orders = []
 
-        # We need k < m for the BIC and AIC calculation, which 
+        # We need k < m for the BIC and AIC calculation, which
         # is why we only test up to maxOrder - 1
         for k in range(1, maxOrder):
             if k not in self.P:
@@ -189,7 +188,7 @@ class MarkovSequence:
 
             orders.append(k)
 
-            if method == 'AIC':                
+            if method == 'AIC':
                 values.append(self.getAIC(k, maxOrder))
             elif method == 'BIC':
                 values.append(self.getBIC(k, maxOrder))

--- a/tests/test_Path.py
+++ b/tests/test_Path.py
@@ -64,9 +64,12 @@ def test_read_edges_undirected(path_from_edge_file_undirected):
 
 
 def test_get_sequence(path_from_ngram_file):
+    from collections import Counter
     """Test if the Paths.getSequence function works correctly"""
     sequence = path_from_ngram_file.getSequence()
-    assert "".join(sequence) == 'dedab|dedab|dedab|dedab|abcdab|abcdab|', \
+    sequence = "".join(sequence)
+    ct = Counter(sequence.split('|'))
+    assert dict(ct) == {'': 1, 'abcdab': 2, 'dedab': 4}, \
         "Returned the wrong sequence"
 
 
@@ -138,20 +141,25 @@ def test_get_contained_paths():
 
 
 def test_filter_paths(path_from_ngram_file):
+    from collections import Counter
     p = path_from_ngram_file
     new_paths = p.filterPaths(node_filter=['a', 'b', 'c'])
-    expected_sequence = "ab|ab|ab|ab|ab|ab|abc|abc|"
+    expected_sequence = {'': 1, 'ab': 6, 'abc': 2}
+
     new_sequence = ''.join(new_paths.getSequence())
-    assert new_sequence == expected_sequence
+    ct = Counter(new_sequence.split('|'))
+    assert dict(ct) == expected_sequence
 
 
 def test_project_paths(path_from_ngram_file):
+    from collections import Counter
     p = path_from_ngram_file
     mapping = {'a': 'x', 'b': 'x', 'c': 'y', 'd': 'y', 'e': 'y'}
     new_p = p.projectPaths(mapping=mapping)
     new_sequence = ''.join(new_p.getSequence())
-    expected_sequence = "yyyxx|yyyxx|yyyxx|yyyxx|xxyyxx|xxyyxx|"
-    assert new_sequence == expected_sequence
+    ct = Counter(new_sequence.split('|'))
+    expected_sequence = {'': 1, 'xxyyxx': 2, 'yyyxx': 4}
+    assert dict(ct) == expected_sequence
 
 
 def test_get_nodes(random_paths):
@@ -159,6 +167,3 @@ def test_get_nodes(random_paths):
     rest = p.getNodes()
     expected = {'b', 'o', 'u', 'v', 'w', 'y'}
     assert rest == expected
-
-
-


### PR DESCRIPTION
Two files are turning all Warning into Errors, which does not work well with ipython, which issues
a DeprecationWarning in its most recent release and will be there for the some time.
This also breaks auto complete functionality in jupyter notebooks.

This removes the warning filter and fixes it. The suggestion for the fix comes from ipython/ipython#10715

Some of the differences between the files are due to the removal of dangling whitespace.
All test have passed